### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through a stack trace

### DIFF
--- a/apps/web/app/api/spotify/[...path]/route.js
+++ b/apps/web/app/api/spotify/[...path]/route.js
@@ -27,8 +27,10 @@ async function handler(req, { params }) {
   try {
     accessToken = await getValidAccessToken(sb, user.id);
   } catch (e) {
+    // Log full error details on the server for debugging
     console.error('[proxy] token error:', e);
-    return new NextResponse(JSON.stringify({ error: 'token_error', message: String(e) }), { status: 401 });
+    // Respond with a generic error message to the client
+    return new NextResponse(JSON.stringify({ error: 'token_error', message: 'An unexpected error occurred.' }), { status: 401 });
   }
 
   const path = params?.path?.join('/') ?? 'me';


### PR DESCRIPTION
Potential fix for [https://github.com/COSC481W-2025Fall/Vybe/security/code-scanning/1](https://github.com/COSC481W-2025Fall/Vybe/security/code-scanning/1)

To fix the problem, the handler should avoid sending the raw error message (especially via `String(e)`) in responses to the client. Instead, log the error on the server for debugging, and return only a generic error message to the client, such as "An unexpected error occurred" or "token_error". This prevents any revealing stack trace or technical details from reaching end users. The code changes should be limited to the error handling block in the `catch` around `getValidAccessToken` (lines 29-32) in `apps/web/app/api/spotify/[...path]/route.js`, replacing the exposure of `String(e)` with a static string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
